### PR TITLE
Reduce memory usage

### DIFF
--- a/csv_to_sqlite.py
+++ b/csv_to_sqlite.py
@@ -100,7 +100,7 @@ class CsvFileInfo:
         currentBatch = 0
         reader = self.get_restarted_reader()
         buf = []
-        maxL = 10001
+        maxL = 10000
         next(reader) #skip headers
         for line in reader:
             buf.append(line)
@@ -113,6 +113,12 @@ class CsvFileInfo:
                 linesTotal += currentBatch
                 currentBatch = 0
                 buf = []
+        if len(buf) > 0:
+            write_out("Flushing the remaining {0} records into {1}".format(len(buf), self.get_table_name()))
+            connection.executemany('insert into [{tableName}] values ({cols})'
+                                   .format(tableName=self.get_table_name(), cols=','.join(['?'] * cols)),
+                                   buf)
+            linesTotal += len(buf)
         return linesTotal
 
 
@@ -134,7 +140,7 @@ none: no typing, every column is string""",
               default='quick')
 @click.option("--drop-tables/--no-drop-tables", "-D",
               help="Determines whether the tables should be dropped before creation, if they already exist"
-                   "(BEWARE OF DATA LOSS)",
+                   " (BEWARE OF DATA LOSS)",
               default=False)
 @click.option("--verbose", "-v",
               is_flag=True,

--- a/csv_to_sqlite.py
+++ b/csv_to_sqlite.py
@@ -7,7 +7,7 @@ import click
 import time
 
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'
 
 def write_out(msg):
     if write_out.verbose:
@@ -128,7 +128,7 @@ def start(file, output, find_types, drop_tables, verbose, delimiter):
     conn = sqlite3.connect(output)
     defaults = CsvOptions(determine_column_types=find_types, drop_tables=drop_tables, delimiter=delimiter)
     totalRowsInserted = 0
-    startTime = time.clock()
+    startTime = time.perf_counter()
     with click.progressbar(files) as _files:
         actual = files if verbose else _files
         for file in actual:
@@ -140,7 +140,7 @@ def start(file, output, find_types, drop_tables, verbose, delimiter):
                 totalRowsInserted += info.save_to_db(conn)
             except Exception as exc:
                 print("Error on table {0}: \n {1}".format(info.get_table_name(), exc))
-    print("Written {0} rows into {1} tables in {2:.3f} seconds".format(totalRowsInserted, len(files), time.clock() - startTime))
+    print("Written {0} rows into {1} tables in {2:.3f} seconds".format(totalRowsInserted, len(files), time.perf_counter() - startTime))
     conn.commit()
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've generated a ~500MB CSV, the import of which took about ~4GB of memory. 
After implementing these changes, it seems the import runs with ~15MB.  

The entire file is no loaded into memory. However, this has necessitated some changes to type detection; see help for details. (tl;dr: by default, the types are now only based the contents of the first data row.)

Fixes #5 
Fixes #3 