### PR TITLE
Use flit_core as build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "csv_to_sqlite"


### PR DESCRIPTION
Also specify a version range; this will mean building carries on working with flit_core 3.x even when 4.x comes with changes.